### PR TITLE
Update README with new deprecation dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ ls ./csar-output
 The client with the required roles is authenticated and an access token is
 available for accessing the required platform APIs.
 
-> Authenticating a user with JSession ID is deprecated, and will be removed
-> in EIC 1.2438. If you still need to authenticate with a JSession ID,
+> Authenticating a user with JSession ID is deprecated. It will be
+> available until release EIC 1.2513 (2025 Q1).
+> If you still need to authenticate with a JSession ID,
 > please follow:
 > [Onboarding the App with JSESSIONID](https://developer.intelligentautomationplatform.ericsson.net/#tutorials/go-sample-app?step=5&chapter=onboarding-the-app-with-jsessionid)
 > in the *Build, onboard and instantiate a 'Hello World App' in Go* tutorial.
@@ -588,9 +589,10 @@ Within the log viewer, you can filter for App Logging and view the results.
 Use Service Exposure to expose the Hello World App API.
 For details, see [Service Exposure - Developer Guide](https://developer.intelligentautomationplatform.ericsson.net/#capabilities/service-exposure/api-exposure-developer-guide).
 
-> Onboarding with Service Exposure API V1 is deprecated,
-> and will be removed in EIC 1.2438. If you still need to
-> onboard with Service Exposure API V1, please follow:
+> Onboarding with Service Exposure API V1 is deprecated.
+> It will be available until release EIC 1.2513 (2025 Q1).
+> If you still need to onboard with Service Exposure API V1,
+> please follow:
 > [Step 2: Onboard the Hello World App APIs using Legacy Service Exposure](https://developer.intelligentautomationplatform.ericsson.net/#tutorials/go-sample-app?step=6&chapter=step-2-onboard-the-hello-world-apis-with-legacy-sef)
 > in the *Build, onboard and instantiate a 'Hello World App' in Go*
 > tutorial.

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ ls ./csar-output
 The client with the required roles is authenticated and an access token is
 available for accessing the required platform APIs.
 
-> Authenticating a user with JSession ID is deprecated. It will be
-> available until release EIC 1.2513 (2025 Q1).
+> Authenticating a user with JSession ID is deprecated
+> alongside the Service Exposure API V1 capability.
+> Please see [Deprecation timelines](https://developer.intelligentautomationplatform.ericsson.net/#support/deprecated/deprecated-timeline)
+> for the deprecation date and status.
 > If you still need to authenticate with a JSession ID,
 > please follow:
 > [Onboarding the App with JSESSIONID](https://developer.intelligentautomationplatform.ericsson.net/#tutorials/go-sample-app?step=5&chapter=onboarding-the-app-with-jsessionid)
@@ -187,9 +189,11 @@ access token:
 
 ### Steps for Onboarding
 
-> Onboarding with App Onboarding API V1 is deprecated,
-> and will be removed from EIC after 2024 Q4. If you still need to
-> onboard with App Onboarding API V1, please follow:
+> Onboarding with App Onboarding API V1 is deprecated.
+> Please see [Deprecation timelines](https://developer.intelligentautomationplatform.ericsson.net/#support/deprecated/deprecated-timeline)
+> for the deprecation date and status.
+> If you still need to onboard with App Onboarding API V1,
+> please follow:
 > [Onboarding the App with JSESSIONID](https://developer.intelligentautomationplatform.ericsson.net/#tutorials/go-sample-app?step=5&chapter=onboarding-the-app-with-jsessionid)
 > in the *Build, onboard and instantiate a 'Hello World App' in Go*
 > tutorial.
@@ -376,9 +380,11 @@ Example of command result:
 
 ## Instantiate the App
 
-> Instantiating with App LCM API V1 is deprecated,
-> and will be removed from EIC after 2024 Q4. If you still need to
-> onboard with App LCM API V1, please follow:
+> Instantiating with App LCM API V1 is deprecated.
+> Please see [Deprecation timelines](https://developer.intelligentautomationplatform.ericsson.net/#support/deprecated/deprecated-timeline)
+> for the deprecation date and status.
+> If you still need to onboard with App LCM API V1,
+> please follow:
 > [Instantiating the App with JSESSIONID](https://developer.intelligentautomationplatform.ericsson.net/#tutorials/go-sample-app?step=6&chapter=instiating-app-with-jsessionid)
 > in the *Build, onboard and instantiate a 'Hello World App' in Go*
 > tutorial.
@@ -590,7 +596,8 @@ Use Service Exposure to expose the Hello World App API.
 For details, see [Service Exposure - Developer Guide](https://developer.intelligentautomationplatform.ericsson.net/#capabilities/service-exposure/api-exposure-developer-guide).
 
 > Onboarding with Service Exposure API V1 is deprecated.
-> It will be available until release EIC 1.2513 (2025 Q1).
+> Please see [Deprecation timelines](https://developer.intelligentautomationplatform.ericsson.net/#support/deprecated/deprecated-timeline)
+> for the deprecation date and status.
 > If you still need to onboard with Service Exposure API V1,
 > please follow:
 > [Step 2: Onboard the Hello World App APIs using Legacy Service Exposure](https://developer.intelligentautomationplatform.ericsson.net/#tutorials/go-sample-app?step=6&chapter=step-2-onboard-the-hello-world-apis-with-legacy-sef)


### PR DESCRIPTION
The deprecation dates for Service Exposure V1 APIs and User Access to REST APIs documenting authentication with JESSIONID have been changed. 
The README has been updated to reflect that change by providing a link to a new space on the Developer Portal, which displays all deprecation timelines, this change was applied to all notes mentioning deprecation for consistency.