### PR TITLE
Set imagePullPolicy to Always

### DIFF
--- a/charts/eric-oss-hello-world-python-app/values.yaml
+++ b/charts/eric-oss-hello-world-python-app/values.yaml
@@ -5,7 +5,7 @@ global:
   timezone: UTC
   registry:
     url: armdocker.rnd.ericsson.se
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
   pullSecret:
   internalIPFamily:
 


### PR DESCRIPTION
Enables faster development when building the Docker image as the image tag will not need to be updated with each iteration.